### PR TITLE
feat: add custom parser support to Env provider

### DIFF
--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::{Profile, Provider, Metadata};
 use crate::coalesce::Coalescible;
-use crate::value::{Map, Dict};
+use crate::value::{Dict, Map, Value};
 use crate::error::Error;
 use crate::util::nest;
 
@@ -12,14 +12,26 @@ crate::util::cloneable_fn_trait!(
     FilterMap: for<'a> Fn(&'a UncasedStr) -> Option<Uncased<'a>> + 'static
 );
 
+mod parser {
+    use std::fmt;
+    use crate::value::Value;
+
+    crate::util::cloneable_fn_trait!(
+        pub Parser: for<'a> Fn(&'a str) -> Value
+    );
+}
+
+use parser::Parser;
+
 /// A [`Provider`] that sources its values from environment variables.
 ///
 /// All key-lookups and comparisons are case insensitive, facilitated by the
 /// [`UncasedStr`] and [`Uncased`] types. By default, environment variable names
 /// are lowercased before being emitted as [key paths] in the provided data, but
 /// this default can be changed with [`Env::lowercase()`]. Environment variable
-/// values can contain structured data, parsed as a [`Value`], with syntax
-/// resembling TOML:
+/// values can contain structured data, parsed as a [`Value`], possibly with a
+/// custom parser specified with [`Env::parser()`], with syntax resembling TOML
+/// by default:
 ///
 ///   * [`Bool`]: `true`, `false` (e.g, `APP_VAR=true`)
 ///   * [`Num::F64`]: any float containing `.`: (e.g, `APP_VAR=1.2`, `APP_VAR=-0.002`)
@@ -110,6 +122,8 @@ pub struct Env {
     prefix: Option<String>,
     /// We use this to generate better metadata when available.
     lowercase: bool,
+    /// Custom parser function
+    parser_fn: Box<dyn Parser>,
 }
 
 impl fmt::Debug for Env {
@@ -125,6 +139,7 @@ impl Env {
             profile: Profile::Default,
             prefix: None,
             lowercase: true,
+            parser_fn: Box::new(|v| v.parse().expect("infallible")),
         }
     }
 
@@ -137,7 +152,65 @@ impl Env {
             profile: self.profile,
             prefix: self.prefix,
             lowercase: true,
+            parser_fn: self.parser_fn,
         }
+    }
+
+    /// Use a custom parser function for environment variable values. This allows any
+    /// format like JSON or YAML in the values.
+    ///
+    /// ```rust
+    /// use figment2::{Figment, Jail, providers::Env};
+    ///
+    /// #[derive(serde::Deserialize)]
+    /// struct Config {
+    ///     foo: Vec<u32>,
+    ///     bar: BarStruct,
+    ///     int_value: u32,
+    /// }
+    ///
+    /// #[derive(serde::Deserialize, PartialEq, Debug)]
+    /// struct BarStruct {
+    ///     x: u32,
+    /// }
+    ///
+    /// Jail::expect_with(|jail| {
+    ///     jail.set_env("FOO", "[1, 2, 3]");
+    ///     jail.set_env("BAR", "{\"x\": 123}");
+    ///     jail.set_env("INT_VALUE", "0");
+    ///
+    ///     let config = Figment::new()
+    ///         .merge(Env::raw().parser(|v| {
+    ///             serde_json::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
+    ///         }))
+    ///         .extract::<Config>()?;
+    ///
+    ///     assert_eq!(config.foo, vec![1, 2, 3]);
+    ///     assert_eq!(config.bar, BarStruct { x: 123 });
+    ///     assert_eq!(config.int_value, 0);
+    ///
+    ///     jail.set_env("FOO", "[\n1 # One\n, 2 # Two\n, 3, # Three\n]");
+    ///     jail.set_env("BAR", "x: 321");
+    ///     jail.set_env("INT_VALUE", "987");
+    ///
+    ///     let config = Figment::new()
+    ///         .merge(Env::raw().parser(|v| {
+    ///             serde_yaml::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
+    ///         }))
+    ///         .extract::<Config>()?;
+    ///
+    ///     assert_eq!(config.foo, vec![1, 2, 3]);
+    ///     assert_eq!(config.bar, BarStruct { x: 321 });
+    ///     assert_eq!(config.int_value, 987);
+    ///
+    ///     Ok(())
+    /// });
+    /// ```
+    pub fn parser<F: Clone + 'static>(mut self, f: F) -> Self
+        where F: for<'a> Fn(&'a str) -> Value
+    {
+        self.parser_fn = Box::new(f);
+        self
     }
 
     /// Constructs and `Env` provider that does not filter or map any
@@ -633,7 +706,9 @@ impl Provider for Env {
     fn data(&self) -> Result<Map<Profile, Dict>, Error> {
         let mut dict = Dict::new();
         for (k, v) in self.iter() {
-            let nested_dict = nest(k.as_str(), v.parse().expect("infallible"))
+            let parsed_value = (self.parser_fn)(&v);
+
+            let nested_dict = nest(k.as_str(), parsed_value)
                 .into_dict()
                 .expect("key is non-empty: must have dict");
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -327,6 +327,12 @@ macro_rules! make_cloneable {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! cloneable_fn_trait {
+    (pub $Name:ident: $($rest:tt)*) => {
+        #[allow(private_bounds)]
+        pub(crate) trait $Name: $($rest)* + Cloneable + 'static { }
+        impl<F: Clone + 'static> $Name for F where F: $($rest)* { }
+        $crate::make_cloneable!($Name: Cloneable);
+    };
     ($Name:ident: $($rest:tt)*) => {
         trait $Name: $($rest)* + Cloneable + 'static { }
         impl<F: Clone + 'static> $Name for F where F: $($rest)* { }

--- a/tests/custom_env_parser.rs
+++ b/tests/custom_env_parser.rs
@@ -1,0 +1,49 @@
+#![cfg(all(feature = "test", feature = "yaml"))]
+use figment2::{Figment, providers::Env};
+
+#[derive(serde::Deserialize)]
+struct Config {
+    foo: Vec<u32>,
+    bar: BarStruct,
+    int_value: u32,
+}
+
+#[derive(serde::Deserialize, PartialEq, Debug)]
+struct BarStruct {
+    x: u32,
+}
+
+#[test]
+fn custom_env_parser() {
+    figment2::Jail::expect_with(|jail| {
+        jail.set_env("FOO", "[1, 2, 3]");
+        jail.set_env("BAR", "{\"x\": 123}");
+        jail.set_env("INT_VALUE", "0");
+
+        let config = Figment::new()
+            .merge(Env::raw().parser(|v| {
+                serde_json::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
+            }))
+            .extract::<Config>()?;
+
+        assert_eq!(config.foo, vec![1, 2, 3]);
+        assert_eq!(config.bar, BarStruct { x: 123 });
+        assert_eq!(config.int_value, 0);
+
+        jail.set_env("FOO", "[\n1 # One\n, 2 # Two\n, 3, # Three\n]");
+        jail.set_env("BAR", "x: 321");
+        jail.set_env("INT_VALUE", "987");
+
+        let config = Figment::new()
+            .merge(Env::raw().parser(|v| {
+                serde_yaml::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
+            }))
+            .extract::<Config>()?;
+
+        assert_eq!(config.foo, vec![1, 2, 3]);
+        assert_eq!(config.bar, BarStruct { x: 321 });
+        assert_eq!(config.int_value, 987);
+
+        Ok(())
+    });
+}


### PR DESCRIPTION
Submitted as PR at https://github.com/SergioBenitez/Figment/pull/121

Only change was this cfg gate on the test file

```rust
#![cfg(all(feature = "test", feature = "yaml"))]
```