### PR TITLE
chore: replace serde_yaml with serde_norway

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1.0"
 uncased = "0.9.10"
 toml_edit = { version = "0.23", optional = true, default-features = false, features = ["parse", "serde"] }
 serde_json = { version = "1.0", optional = true }
-serde_yaml = { version = "0.9", optional = true }
+serde_yaml = { package = "serde_norway", version = "0.9", optional = true }
 tempfile = { version = "3", optional = true }
 parking_lot = { version = "0.12", optional = true }
 


### PR DESCRIPTION
serde_yaml is long deprecated. serde_norway seems to be the modern and supported fork.