### PR TITLE
refactor: rely on serde_norway crate; deprecate serde_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "serde",
  "serde_default_utils",
  "serde_json",
- "serde_yaml",
+ "serde_norway",
  "tempfile",
  "toml_edit",
  "uncased",
@@ -401,25 +401,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -506,10 +506,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["env"]
 json = ["serde_json"]
 test = ["tempfile", "parking_lot"]
 toml = ["toml_edit"]
-yaml = ["serde_yaml"]
+yaml = ["serde_norway"]
 env = [] # does nothing; here for backwards compat
 
 [dependencies]
@@ -27,7 +27,7 @@ serde = "1.0"
 uncased = "0.9.10"
 toml_edit = { version = "0.23", optional = true, default-features = false, features = ["parse", "serde"] }
 serde_json = { version = "1.0", optional = true }
-serde_yaml = { version = "0.9", optional = true }
+serde_norway = { version = "0.9", optional = true }
 tempfile = { version = "3", optional = true }
 parking_lot = { version = "0.12", optional = true }
 

--- a/src/providers/data.rs
+++ b/src/providers/data.rs
@@ -531,7 +531,7 @@ impl YamlExtended {
     /// This "YAML Extended" format parser implements the draft ["Merge Key
     /// Language-Independent Type for YAML™ Version
     /// 1.1"](https://yaml.org/type/merge.html) spec via
-    /// [`serde_yaml::Value::apply_merge()`]. This method is _not_ intended to
+    /// [`serde_norway::Value::apply_merge()`]. This method is _not_ intended to
     /// be used directly but rather indirectly by making use of `YamlExtended`
     /// as a provider. The extension is not part of any officially supported
     /// YAML release and is deprecated entirely since YAML 1.2. Using
@@ -603,14 +603,14 @@ impl YamlExtended {
     ///     Ok(())
     /// });
     /// ```
-    pub fn from_str<'de, T: DeserializeOwned>(s: &'de str) -> serde_yaml::Result<T> {
-        let mut value: serde_yaml::Value = serde_yaml::from_str(s)?;
+    pub fn from_str<'de, T: DeserializeOwned>(s: &'de str) -> serde_norway::Result<T> {
+        let mut value: serde_norway::Value = serde_norway::from_str(s)?;
         value.apply_merge()?;
         T::deserialize(value)
     }
 }
 
 impl_format!(Toml "TOML"/"toml": toml_edit::de::from_str, toml_edit::de::Error);
-impl_format!(Yaml "YAML"/"yaml": serde_yaml::from_str, serde_yaml::Error);
+impl_format!(Yaml "YAML"/"yaml": serde_norway::from_str, serde_norway::Error);
 impl_format!(Json "JSON"/"json": serde_json::from_str, serde_json::error::Error);
-impl_format!(YamlExtended "YAML Extended"/"yaml": YamlExtended::from_str, serde_yaml::Error);
+impl_format!(YamlExtended "YAML Extended"/"yaml": YamlExtended::from_str, serde_norway::Error);

--- a/src/providers/env.rs
+++ b/src/providers/env.rs
@@ -203,7 +203,7 @@ impl Env {
     ///
     ///     let config = Figment::new()
     ///         .merge(Env::raw().parser(|v| {
-    ///             serde_yaml::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
+    ///             serde_norway::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
     ///         }))
     ///         .extract::<Config>()?;
     ///

--- a/tests/custom_env_parser.rs
+++ b/tests/custom_env_parser.rs
@@ -36,7 +36,7 @@ fn custom_env_parser() {
 
         let config = Figment::new()
             .merge(Env::raw().parser(|v| {
-                serde_yaml::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
+                serde_norway::from_str(v).unwrap_or_else(|_| figment2::value::Value::from(v))
             }))
             .extract::<Config>()?;
 


### PR DESCRIPTION
- A quick re-do of #8, 
  - Better choice than #13 which would add new dependencies and so be more disruptive
- Fulfils #12